### PR TITLE
fix: ignored classes when they are more than 1

### DIFF
--- a/src/datetimepicker.common.ts
+++ b/src/datetimepicker.common.ts
@@ -110,7 +110,10 @@ function getColorsForClassName(view: View, className: string): { color: Color, b
         tempView[vueKey] = view[vueKey];
     }
     if (view.className) {
-        tempView.cssClasses.add(view.className);
+        let classNames = view.className.split(' ');
+        classNames.forEach(element => {
+            tempView.cssClasses.add(element);
+        });
     }
     if (className) {
         tempView.cssClasses.add(className);


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing

## What is the current behavior?
When a DatePickerField has 2 class names they are ignored

## What is the new behavior?
All DatePickerField's class names are taken into consideration

Related to [this issue](https://github.com/NativeScript/nativescript-datetimepicker/issues/1).

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
