### PR TITLE
feat: androidx support

### DIFF
--- a/src/datetimepicker.android.ts
+++ b/src/datetimepicker.android.ts
@@ -15,6 +15,19 @@ interface DialogDismissListener {
 
 let DialogClickListener: DialogClickListener;
 let DialogDismissListener: DialogDismissListener;
+let AppCompatNamespace: any;
+declare let androidx: any;
+
+function initializeAppCompatNamespace(): void {
+    if (AppCompatNamespace) {
+        return;
+    }
+    if (androidx && androidx.appcompat) {
+        AppCompatNamespace = androidx.appcompat;
+    } else {
+        AppCompatNamespace = (<any>android.support).v7;
+    }
+}
 
 function initializeDialogClickListener(): void {
     if (DialogClickListener) {
@@ -155,6 +168,7 @@ export class DateTimePicker extends DateTimePickerBase {
     static _createNativeDialog(nativePicker: android.view.View, options: PickerOptions, value: Date, callback: Function): android.app.AlertDialog.Builder {
         initializeDialogClickListener();
         initializeDialogDismissListener();
+        initializeAppCompatNamespace();
         DateTimePicker._initializeTextResources(options.context);
         const context = options.context;
         let dateTime: Date;
@@ -271,7 +285,7 @@ export class DateTimePicker extends DateTimePickerBase {
                 child.setTextColor(color.android);
             }
         }
-        const filter = android.support.v7.widget.AppCompatDrawableManager.getPorterDuffColorFilter(
+        const filter = AppCompatNamespace.widget.AppCompatDrawableManager.getPorterDuffColorFilter(
             color.android, android.graphics.PorterDuff.Mode.SRC_IN);
         selectionDividerDrawable.setColorFilter(filter);
         numberPicker.invalidate();


### PR DESCRIPTION
## What is the current behavior?
The plugin is not compatible with  _androidx_ versions of _tns-core-modules_ and _tns-android_.

## What is the new behavior?
The plugin is compatible with  both _official_ and _androidx_ versions of _tns-core-modules_ and _tns-android_.

Related with https://github.com/NativeScript/nativescript-datetimepicker/issues/14.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
