### PR TITLE
fix(ios-angular): Topmost deprecation and not rendering on top of modal

### DIFF
--- a/src/datetimepicker.common.ts
+++ b/src/datetimepicker.common.ts
@@ -2,7 +2,7 @@ import { View } from "tns-core-modules/ui/core/view";
 import { ContentView } from "tns-core-modules/ui/content-view";
 import { Page } from "tns-core-modules/ui/page";
 import { Color } from "tns-core-modules/color";
-import * as frameModule from "tns-core-modules/ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 import {
     DateTimePicker as DateTimePickerDefinition,
     DateTimePickerStyle as DateTimePickerStyleDefinition
@@ -76,7 +76,7 @@ export class DateTimePickerStyleBase implements DateTimePickerStyleDefinition {
 }
 
 export function getCurrentPage(): Page {
-    let topmostFrame = frameModule.topmost();
+    let topmostFrame = Frame.topmost();
     if (topmostFrame) {
         return topmostFrame.currentPage;
     }

--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -149,7 +149,7 @@ export class DateTimePicker extends DateTimePickerBase {
                     viewController = parentWithController ? parentWithController.viewController : undefined;
                 }
 
-                if (viewController.presentedViewController) {
+                while (viewController.presentedViewController) {
                     viewController = viewController.presentedViewController;
                 }
             }

--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -148,7 +148,7 @@ export class DateTimePicker extends DateTimePickerBase {
                     const parentWithController = iosView.getParentWithViewController(view);
                     viewController = parentWithController ? parentWithController.viewController : undefined;
                 }
-                
+
                 if (viewController.presentedViewController) {
                     viewController = viewController.presentedViewController;
                 }

--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -144,11 +144,12 @@ export class DateTimePicker extends DateTimePickerBase {
 
                 if (view.ios instanceof UIViewController) {
                     viewController = view.ios;
+                } else if (viewController.presentedViewController) {
+                    viewController = viewController.presentedViewController;
                 } else {
                     const parentWithController = iosView.getParentWithViewController(view);
                     viewController = parentWithController ? parentWithController.viewController : undefined;
                 }
-                viewController = viewController.presentedViewController;
             }
 
             if (viewController) {

--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -144,11 +144,13 @@ export class DateTimePicker extends DateTimePickerBase {
 
                 if (view.ios instanceof UIViewController) {
                     viewController = view.ios;
-                } else if (viewController.presentedViewController) {
-                    viewController = viewController.presentedViewController;
                 } else {
                     const parentWithController = iosView.getParentWithViewController(view);
                     viewController = parentWithController ? parentWithController.viewController : undefined;
+                }
+                
+                if (viewController.presentedViewController) {
+                    viewController = viewController.presentedViewController;
                 }
             }
 

--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -148,6 +148,7 @@ export class DateTimePicker extends DateTimePickerBase {
                     const parentWithController = iosView.getParentWithViewController(view);
                     viewController = parentWithController ? parentWithController.viewController : undefined;
                 }
+                viewController = viewController.presentedViewController;
             }
 
             if (viewController) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
iOS gives a warning about deprecation of topmost() and does not render the datetimepicker on top of a modal in Angular.

## What is the new behavior?
iOS gives no warning about deprecation of topmost() and does render the datetimepicker on top of a modal in Angular.

Fixes/Implements/Closes #60.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

