### PR TITLE
Fix datetimepicker not opening on versions below iOS 14

### DIFF
--- a/src/datetimepicker.ios.ts
+++ b/src/datetimepicker.ios.ts
@@ -189,7 +189,7 @@ export class DateTimePicker extends DateTimePickerBase {
         }
         if (color) {
             if (this.SUPPORT_TEXT_COLOR) {
-                nativePicker.setValueForKey(color, 'textColor');
+                nativePicker.setValueForKey(color.ios, 'textColor');
             }
             nativePicker.setValueForKey(false, "highlightsToday");
         }


### PR DESCRIPTION
Fix #78 

Tested and confirmed working on a simulation iPhone 6s on iOS 12.4 and 14.0